### PR TITLE
feat: halt_on_error for ControllerV2 reconciler streams

### DIFF
--- a/lib/bonny/controller_v2.ex
+++ b/lib/bonny/controller_v2.ex
@@ -87,6 +87,8 @@ defmodule Bonny.ControllerV2 do
 
   use Supervisor
 
+  require Logger
+
   @type api :: binary()
   @type resource :: binary()
   @type verb :: binary()
@@ -130,16 +132,20 @@ defmodule Bonny.ControllerV2 do
     operator = Keyword.fetch!(init_args, :operator)
     reconcile_timeout = Keyword.get(init_args, :reconcile_timeout, 5_000)
     termination_delay = Keyword.get(init_args, :termination_delay, 60_000)
+    halt_on_error = Keyword.get(init_args, :halt_on_error, true)
     conn = Keyword.get_lazy(init_args, :conn, fn -> Bonny.Config.conn() end)
 
-    watcher_stream =
-      Bonny.Server.Watcher.get_raw_stream(conn, ensure_watch_query(query))
-      |> Stream.map(&Bonny.Operator.run(&1, controller, operator, conn))
+    watcher_stream = build_watcher_stream(conn, query, controller, operator)
 
     reconciler_stream =
-      conn
-      |> Bonny.Server.Reconciler.get_raw_stream(ensure_list_query(query))
-      |> Task.async_stream(&Bonny.Operator.run({:reconcile, &1}, controller, operator, conn),[timeout: reconcile_timeout])
+      build_reconciler_stream(
+        Bonny.Server.Reconciler.get_raw_stream(conn, ensure_list_query(query)),
+        controller,
+        operator,
+        conn,
+        reconcile_timeout: reconcile_timeout,
+        halt_on_error: halt_on_error
+      )
 
     children = [
       {Bonny.Server.AsyncStreamRunner, id: Watcher, stream: watcher_stream},
@@ -152,6 +158,45 @@ defmodule Bonny.ControllerV2 do
       strategy: :one_for_one,
       max_restarts: 20,
       max_seconds: 120
+    )
+  end
+
+  @doc false
+  def build_watcher_stream(conn, query, controller, operator) do
+    Bonny.Server.Watcher.get_raw_stream(conn, ensure_watch_query(query))
+    |> Stream.map(&Bonny.Operator.run(&1, controller, operator, conn))
+  end
+
+  @doc false
+  def build_reconciler_stream(resource_stream, controller, operator, conn, opts \\ []) do
+    reconcile_timeout = Keyword.get(opts, :reconcile_timeout, 5_000)
+    halt_on_error = Keyword.get(opts, :halt_on_error, true)
+    max_concurrency = Keyword.get(opts, :max_concurrency, System.schedulers_online())
+
+    Task.async_stream(
+      resource_stream,
+      fn resource ->
+        try do
+          Bonny.Operator.run({:reconcile, resource}, controller, operator, conn)
+        rescue
+          error ->
+            if halt_on_error, do: reraise(error, __STACKTRACE__)
+
+            Logger.error("Reconcile failed (continuing list pass)",
+              name: K8s.Resource.name(resource),
+              namespace: K8s.Resource.namespace(resource),
+              kind: K8s.Resource.kind(resource),
+              api_version: resource["apiVersion"],
+              error: error,
+              stacktrace: __STACKTRACE__,
+              library: :bonny
+            )
+
+            :error
+        end
+      end,
+      timeout: reconcile_timeout,
+      max_concurrency: max_concurrency
     )
   end
 

--- a/test/bonny/controller_v2_test.exs
+++ b/test/bonny/controller_v2_test.exs
@@ -1,0 +1,112 @@
+defmodule Bonny.ControllerV2Test do
+  use ExUnit.Case, async: false
+
+  alias Bonny.ControllerV2
+
+  @conn %K8s.Conn{}
+  @controller {Bonny.ControllerV2Test.Controller, []}
+  @agent_name Bonny.ControllerV2Test.CountingAgent
+
+  defmodule Controller do
+    use Bonny.ControllerV2
+    step :handle_event
+    def handle_event(axn, _), do: axn
+  end
+
+  defmodule CountingOperator do
+    def call(%Bonny.Axn{action: action, resource: resource} = axn, []) do
+      name = resource["metadata"]["name"]
+      Agent.update(Bonny.ControllerV2Test.CountingAgent, &(&1 ++ [{action, name}]))
+
+      if name == "fail", do: raise("event failed")
+
+      axn
+    end
+  end
+
+  setup do
+    if pid = Process.whereis(@agent_name), do: Agent.stop(pid)
+    {:ok, _} = Agent.start_link(fn -> [] end, name: @agent_name)
+    :ok
+  end
+
+  defp resource(name) do
+    %{
+      "apiVersion" => "v1",
+      "kind" => "ConfigMap",
+      "metadata" => %{"name" => name, "namespace" => "default"}
+    }
+  end
+
+  defp watch_stream(events) do
+    Stream.map(events, &Bonny.Operator.run(&1, @controller, CountingOperator, @conn))
+  end
+
+  describe "build_reconciler_stream/5" do
+    test "halt_on_error false continues the list pass after failure" do
+      resources = [resource("fail"), resource("ok-1"), resource("ok-2")]
+
+      stream =
+        ControllerV2.build_reconciler_stream(
+          resources,
+          @controller,
+          CountingOperator,
+          @conn,
+          halt_on_error: false
+        )
+
+      assert [{:ok, :error}, {:ok, _}, {:ok, _}] = Enum.to_list(stream)
+
+      assert MapSet.new(Agent.get(@agent_name, & &1)) ==
+               MapSet.new([{:reconcile, "fail"}, {:reconcile, "ok-1"}, {:reconcile, "ok-2"}])
+    end
+
+    test "halt_on_error true stops the list pass on first failure" do
+      resources = [resource("fail"), resource("ok-1")]
+
+      stream =
+        ControllerV2.build_reconciler_stream(
+          resources,
+          @controller,
+          CountingOperator,
+          @conn,
+          halt_on_error: true,
+          max_concurrency: 1
+        )
+
+      {_, ref} = spawn_monitor(fn -> Enum.to_list(stream) end)
+
+      assert_receive {:DOWN, ^ref, :process, _, reason}, 5_000
+      assert reason != :normal
+      assert Agent.get(@agent_name, & &1) == [{:reconcile, "fail"}]
+    end
+  end
+
+  describe "watch stream" do
+    test "processes add, modify, and delete events" do
+      events = [
+        {:add, resource("new")},
+        {:modify, resource("updated")},
+        {:delete, resource("gone")}
+      ]
+
+      Stream.run(watch_stream(events))
+
+      assert Agent.get(@agent_name, & &1) == [
+               {:add, "new"},
+               {:modify, "updated"},
+               {:delete, "gone"}
+             ]
+    end
+
+    test "failure crashes the stream (halt_on_error not applicable)" do
+      events = [{:add, resource("ok")}, {:modify, resource("fail")}, {:delete, resource("never")}]
+
+      {_, ref} = spawn_monitor(fn -> Stream.run(watch_stream(events)) end)
+
+      assert_receive {:DOWN, ^ref, :process, _, reason}, 5_000
+      assert reason != :normal
+      assert Agent.get(@agent_name, & &1) == [{:add, "ok"}, {:modify, "fail"}]
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Wire `halt_on_error` from controller init args into periodic reconcile `Task.async_stream`.
- When `false`, rescue reconcile failures so the list pass continues; when `true`, preserve linked-task crash behaviour.
- Extract `build_reconciler_stream/5` and `build_watcher_stream/4` (same pipelines as `ControllerV2.init/1`).
- When continuing after reconcile failures, log resource metadata (`namespace`, `kind`, `api_version`) and stacktrace.
- Add integration tests for reconcile `halt_on_error` (true/false), watcher `:add`/`:modify`/`:delete` events, and watch failure behaviour (`halt_on_error` does not apply to the watcher stream).

## Test plan
- [x] `mix test test/bonny/controller_v2_test.exs` (4 tests)